### PR TITLE
Update website to include MIAPPE version 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# gem "rails"
+gem 'github-pages', group: :jekyll_plugins
+

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ order: 1
 	</ul>
 	
         <h3>About MIAPPE</h3>
-	<p>MIAPPE is an open, community driven, data standard designed to harmonize data from plant phenotyping experiments. 
+	<p>MIAPPE is an open and community-driven data standard designed to harmonize data from plant phenotyping experiments. 
 		MIAPPE provides a specification including a checklist and a data model of metadata required to adequately describe plant phenotyping experiments. 
 		You can have a quick <a href="https://www.miappe.org/overview/">overview</a> or go the the primer section below.
 		Those specifications are implemented in several tools, databases and file templates and exchange formats that allow to   
@@ -38,7 +38,7 @@ order: 1
 	<h5>Mailing list registration</h5>
 	<p>
 		You can subscribe to the <a href="https://mail.elixir-europe.org/mailman/listinfo/miappe_elixir-europe.org">MIAPPE mailing list</a>
-		to join the community or simply get the latest informations. 
+		to join the community or simply get the latest information. 
 	</p>
 		
 

--- a/index.html
+++ b/index.html
@@ -87,6 +87,13 @@ order: 1
 	<p>
 
 <h3>Releases</h3>
+<h4>MIAPPE v1.2, October 2024</h4>
+<p>
+	<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.pdf">MIAPPE version 1.2</a> has some
+	additions as well as minor improvements and clarifications. It remains fully compatible with MIAPPE v1.1. A summary of
+	changes is available in the <a href="https://github.com/MIAPPE/MIAPPE/blob/master/RELEASE-NOTES.md">Release Notes</a>.
+</p>
+
 <h4>MIAPPE v1.1, January 2019</h4>
 	<p>
 		<a href="https://github.com/MIAPPE/MIAPPE/tree/v1.1/MIAPPE_Checklist-Data-Model-v1.1">MIAPPE version 1.1</a>,

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@ order: 1
 <h3>Releases</h3>
 <h4>MIAPPE v1.1, January 2019</h4>
 	<p>
-		<a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-Data-Model-v1.1">MIAPPE version 1.1</a>,
+		<a href="https://github.com/MIAPPE/MIAPPE/tree/v1.1/MIAPPE_Checklist-Data-Model-v1.1">MIAPPE version 1.1</a>,
 		released on 10th January 2019, relied on two requests for comments.  Major developments over v1.0 include:
 	</p> 
 	<ul>
@@ -113,7 +113,7 @@ order: 1
 	</p> 	
 <h4>MIAPPE v1, July 2016</h4>
 	<p>
-		The <a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-v1.0">initial version of MIAPPE</a> has
+		The <a href="https://github.com/MIAPPE/MIAPPE/tree/v1.1/MIAPPE_Checklist-v1.0">initial version of MIAPPE</a> has
 		been designed as a checklist, following the approach of international deposition databases. It is now extended by
 		MIAPPE v1.1.
 	</p>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ order: 1
 				<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.pdf">PDF</a> and
 				<a href="https://github.com/MIAPPE/MIAPPE/raw/refs/heads/master/MIAPPE_Checklist_Data_Model.xlsx">Excel</a> format.</li>
 		</ul>
-	<li>Training and exchange <a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-Data-Model-v1.1/MIAPPE_templates">templates</a></li>
+	<li>Training and exchange <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">templates</a></li>
 	<li><a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-Data-Model-v1.1/MIAPPE_mapping">Mapping</a> between MIAPPE and other standards (<a href="https://isa-tools.org:">ISA-Tools</a> , <a href="https://brapi.docs.apiary.io/#">Breeding API (BrAPI)</a>)</li>
 	</ul>
 	

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ order: 1
 				<a href="https://github.com/MIAPPE/MIAPPE/raw/refs/heads/master/MIAPPE_Checklist_Data_Model.xlsx">Excel</a> format.</li>
 		</ul>
 	<li>Training and exchange <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">templates</a></li>
-	<li><a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-Data-Model-v1.1/MIAPPE_mapping">Mapping</a> between MIAPPE and other standards (<a href="https://isa-tools.org:">ISA-Tools</a> , <a href="https://brapi.docs.apiary.io/#">Breeding API (BrAPI)</a>)</li>
+	<li><a href="https://github.com/MIAPPE/MIAPPE/blob/master/Mapping/MIAPPE_Checklist_Mapping.tsv">Mapping</a> between MIAPPE and other standards (<a href="https://isa-tools.org:">ISA-Tools</a> , <a href="https://brapi.docs.apiary.io/#">Breeding API (BrAPI)</a>)</li>
 	</ul>
 	
         <h3>About MIAPPE</h3>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ order: 1
   	<p>
 		MIAPPE is a <a href="http://www.nature.com/nbt/journal/v26/n8/full/nbt.1411.html">Minimum Information (MI)</a>
 		standard for plant phenotyping.  It defines a list of attributes that might be necessary to fully describe a
-		phenotyping experiment, following <a href="http://fged.org/projects/miame/">the model originally established for
+		phenotyping experiment, following <a href="https://www.fged.org/projects/miame">the model originally established for
 		microarray data</a>. Not all of the elements listed in an MI must be reported in each case. An MI document should
 		rather be considered as a checklist, and consulted by a person describing or depositing the data to ensure the
 		inclusion of all important data characteristics, i.e. what is meaningful for the interpretation and potential

--- a/index.html
+++ b/index.html
@@ -108,8 +108,9 @@ order: 1
 	<p>
 		A <a href="https://nph.onlinelibrary.wiley.com/doi/abs/10.1111/nph.16544">new paper</a> describing the application of
 		MIAPPE v1.1 to a variety of use cases was published in the New Phytologist.
-		Meanwhile, improvements can be suggested via miappe-feedback@ebi.ac.uk.  Work is now commencing on the next version of
-		MIAPPE, v2.0.  Development is at an early stage and all contributions are welcome.
+		Meanwhile, improvements can be suggested via <a href="https://github.com/MIAPPE/MIAPPE/issues">GitHub Issues</a>.
+		Work is now commencing on the next version of MIAPPE, v2.0.  Development is at an early stage and all contributions
+		are welcome.
 	</p> 	
 <h4>MIAPPE v1, July 2016</h4>
 	<p>

--- a/index.html
+++ b/index.html
@@ -100,8 +100,8 @@ order: 1
 	</li>
 	<li>
 		Compatibility of the MIAPPE logical standard with common frameworks for representing these data types, namely
-		<a href="https://isa-tools.org:">ISA-Tools</a> and the
-		<a href="https://brapi.docs.apiary.io/#">Breeding API (BrAPI)</a>.
+		<a href="https://isa-tools.org">ISA-Tools</a> and the
+		<a href="https://brapi.org">Breeding API (BrAPI)</a>.
 	</li>
 	<li>The enrichment of MIAPPE, with the provision of clear definitions and examples for all fields.</li>
 	</ul>

--- a/index.html
+++ b/index.html
@@ -58,14 +58,14 @@ order: 1
 	<p>
 		Plant phenotyping data is diverse, dispersed and increasingly plentiful owing to the application of new automated
 		techniques.  While various initiatives have explored how to describe plant traits (e.g. the
-		<a href="http://browser.planteome.org/amigo/term/TO:0000387#display-lineage-tab">Plant Trait Ontology</a>) and
+		<a href="https://browser.planteome.org/amigo/term/TO:0000387#display-lineage-tab">Plant Trait Ontology</a>) and
 		phenotypes, description of the experimental design that provides the context for phenotypic observations is not
 		well-standardized. A basic description of the materials used and the experiment performed is needed to support data
 		discovery and data mining applications. MIAPPE – the Minimal Information About a Plant Phenotyping Experiment – is in
 		development to address these needs.
 	</p>
   	<p>
-		MIAPPE is a <a href="http://www.nature.com/nbt/journal/v26/n8/full/nbt.1411.html">Minimum Information (MI)</a>
+		MIAPPE is a <a href="https://www.nature.com/nbt/journal/v26/n8/full/nbt.1411.html">Minimum Information (MI)</a>
 		standard for plant phenotyping.  It defines a list of attributes that might be necessary to fully describe a
 		phenotyping experiment, following <a href="https://www.fged.org/projects/miame">the model originally established for
 		microarray data</a>. Not all of the elements listed in an MI must be reported in each case. An MI document should
@@ -76,8 +76,8 @@ order: 1
  
 	<p>
 		MIAPPE is a logical standard - but there are specific implementations of tools designed to support its use and
-		application, for example, in the <a hef="http://isa-tools.org">ISA-tools</a> framework. We are working with the
-		developers of the <a href="http://www.brapi.org">Plant Breeding API</a> (BRAPI) to ensure the compliance of BRAPI with
+		application, for example, in the <a href="https://isa-tools.org">ISA-tools</a> framework. We are working with the
+		developers of the <a href="https://www.brapi.org">Plant Breeding API</a> (BRAPI) to ensure the compliance of BRAPI with
 		the MIAPPE standard, and to coordinate future developments.
 	</p>
  	<p>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ order: 1
 				<a href="https://github.com/MIAPPE/MIAPPE/raw/refs/heads/master/MIAPPE_Checklist_Data_Model.xlsx">Excel</a> format.</li>
 		</ul>
 	<li>Training and exchange <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">templates</a></li>
-	<li><a href="https://github.com/MIAPPE/MIAPPE/blob/master/Mapping/MIAPPE_Checklist_Mapping.tsv">Mapping</a> between MIAPPE and other standards (<a href="https://isa-tools.org:">ISA-Tools</a> , <a href="https://brapi.docs.apiary.io/#">Breeding API (BrAPI)</a>)</li>
+	<li><a href="https://github.com/MIAPPE/MIAPPE/blob/master/Mapping/MIAPPE_Checklist_Mapping.tsv">Mapping</a> between MIAPPE and other standards (<a href="https://isa-tools.org:">ISA-Tools</a> , <a href="https://brapi.org/">Breeding API (BrAPI)</a>)</li>
 	</ul>
 	
         <h3>About MIAPPE</h3>

--- a/index.html
+++ b/index.html
@@ -81,15 +81,17 @@ order: 1
 		the MIAPPE standard, and to coordinate future developments.
 	</p>
  	<p>
-		MIAPPE was originally been developed in the context of the transPLANT, European Plant Phenotyping Network and
+		MIAPPE was originally developed in the context of the transPLANT, European Plant Phenotyping Network and
 		ELIXIR-EXCELERATE projects, but we are keen to work with anyone interested in contributing to, reviewing or using the
 		standard, or developing new tools.
 	<p>
 
 <h3>Releases</h3>
 <h4>MIAPPE v1.1, January 2019</h4>
-	<p><a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-Data-Model-v1.1">MIAPPE version 1.1</a>,released on 10th January 2019, 
-		relied on two requests for comments.  Major developments over v1.0 include:</p> 
+	<p>
+		<a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-Data-Model-v1.1">MIAPPE version 1.1</a>,
+		released on 10th January 2019, relied on two requests for comments.  Major developments over v1.0 include:
+	</p> 
 	<ul>
 	<li>The extension of MIAPPE’s scope to accommodate woody plants as an additional use-case.</li>
 	<li>
@@ -105,7 +107,7 @@ order: 1
 	</ul>
 	<p>
 		A <a href="https://nph.onlinelibrary.wiley.com/doi/abs/10.1111/nph.16544">new paper</a> describing the application of
-		MIAPPE v1.1 to a variety of use cases has just been published in the New Phytologist.
+		MIAPPE v1.1 to a variety of use cases was published in the New Phytologist.
 		Meanwhile, improvements can be suggested via miappe-feedback@ebi.ac.uk.  Work is now commencing on the next version of
 		MIAPPE, v2.0.  Development is at an early stage and all contributions are welcome.
 	</p> 	

--- a/index.html
+++ b/index.html
@@ -11,44 +11,80 @@ order: 1
 	See the <a href="https://www.miappe.org/support/">support page</a> for full informations
 	<ul>
 		<li> Quick <a href="https://www.miappe.org/overview/">overview</a> of MIAPPE</li>
-		<li> <a href="https://tess.elixir-europe.org/materials/plant-phenotyping-data-managment-webinar-miappe">Webinar</a>, with video recording and slides introducing the fundamentals of MIAPPE</li>
+		<li>
+			<a href="https://tess.elixir-europe.org/materials/plant-phenotyping-data-managment-webinar-miappe">Webinar</a>,
+			with video recording and slides introducing the fundamentals of MIAPPE
+		</li>
 	<li><b><a href="https://github.com/MIAPPE/MIAPPE">Latest specifications</a></b>
 		<ul>
 			<li><a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_diagram.svg">data model</a> overview </li>
 			<li><a href="https://github.com/MIAPPE/MIAPPE">field list</a> with descriptions and examples in 
 				<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.tsv">tsv</a>,  
 				<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.pdf">PDF</a> and
-				<a href="https://github.com/MIAPPE/MIAPPE/raw/refs/heads/master/MIAPPE_Checklist_Data_Model.xlsx">Excel</a> format.</li>
+				<a href="https://github.com/MIAPPE/MIAPPE/raw/refs/heads/master/MIAPPE_Checklist_Data_Model.xlsx">Excel</a>
+				format.
+			</li>
 		</ul>
 	<li>Training and exchange <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">templates</a></li>
-	<li><a href="https://github.com/MIAPPE/MIAPPE/blob/master/Mapping/MIAPPE_Checklist_Mapping.tsv">Mapping</a> between MIAPPE and other standards (<a href="https://isa-tools.org:">ISA-Tools</a> , <a href="https://brapi.org/">Breeding API (BrAPI)</a>)</li>
+	<li>
+		<a href="https://github.com/MIAPPE/MIAPPE/blob/master/Mapping/MIAPPE_Checklist_Mapping.tsv">Mapping</a> between MIAPPE
+		and other standards (<a href="https://isa-tools.org:">ISA-Tools</a>,
+		<a href="https://brapi.org/">Breeding API (BrAPI)</a>)
+	</li>
 	</ul>
 	
-        <h3>About MIAPPE</h3>
+    <h3>About MIAPPE</h3>
 	<p>MIAPPE is an open and community-driven data standard designed to harmonize data from plant phenotyping experiments. 
-		MIAPPE provides a specification including a checklist and a data model of metadata required to adequately describe plant phenotyping experiments. 
-		You can have a quick <a href="https://www.miappe.org/overview/">overview</a> or go the the primer section below.
-		Those specifications are implemented in several tools, databases and file templates and exchange formats that allow to   
-		validate, store and disseminate MIAPPE-compliant data.  
-		We welcome contributions from anyone interested in plant phenotyping data, inluding linked data.</p>
+		MIAPPE provides a specification including a checklist and a data model of metadata required to adequately describe
+		plant phenotyping experiments. You can have a quick <a href="https://www.miappe.org/overview/">overview</a> or go the
+		primer section below. Those specifications are implemented in several tools, databases and file templates and exchange
+		formats that allow to validate, store and disseminate MIAPPE-compliant data. We welcome contributions from anyone
+		interested in plant phenotyping data, inluding linked data.
+	</p>
 	<p>Development of MIAPPE is an open process, 
 		so if you would like to contribute by commenting, reviewing or participating to the ongoing development, 
 		please let us know via the MIAPPE mailing list. </p>
 		
 	<h5>Mailing list registration</h5>
 	<p>
-		You can subscribe to the <a href="https://mail.elixir-europe.org/mailman/listinfo/miappe_elixir-europe.org">MIAPPE mailing list</a>
+		You can subscribe to the
+		<a href="https://mail.elixir-europe.org/mailman/listinfo/miappe_elixir-europe.org">MIAPPE mailing list</a>
 		to join the community or simply get the latest information. 
 	</p>
 		
 
 	<h3>Background</h3>
 
-	<p>Plant phenotyping data is diverse, dispersed and increasingly plentiful owing to the application of new automated techniques.  While various initiatives have explored how to describe plant traits (e.g. the <a href="http://browser.planteome.org/amigo/term/TO:0000387#display-lineage-tab">Plant Trait Ontology</a>) and phenotypes, description of the experimental design that provides the context for phenotypic observations is not well-standardized.   A basic description of the materials used and the experiment performed is needed to support data discovery and data mining applications.  MIAPPE – the Minimal Information About a Plant Phenotyping Experiment – is in development to address these needs.</p>
-  <p>MIAPPE is a <a href="http://www.nature.com/nbt/journal/v26/n8/full/nbt.1411.html">Minimum Information (MI)</a> standard for plant phenotyping.  It defines a list of attributes that might be necessary to fully describe a phenotyping experiment, following <a href="http://fged.org/projects/miame/">the model originally established for microarray data</a>. Not all of the elements listed in an MI must be reported in each case. An MI document should rather be considered as a checklist, and consulted by a person describing or depositing the data to ensure the inclusion of all important data characteristics, i.e. what is meaningful for the interpretation and potential replication of the research.</p>
+	<p>
+		Plant phenotyping data is diverse, dispersed and increasingly plentiful owing to the application of new automated
+		techniques.  While various initiatives have explored how to describe plant traits (e.g. the
+		<a href="http://browser.planteome.org/amigo/term/TO:0000387#display-lineage-tab">Plant Trait Ontology</a>) and
+		phenotypes, description of the experimental design that provides the context for phenotypic observations is not
+		well-standardized. A basic description of the materials used and the experiment performed is needed to support data
+		discovery and data mining applications. MIAPPE – the Minimal Information About a Plant Phenotyping Experiment – is in
+		development to address these needs.
+	</p>
+  	<p>
+		MIAPPE is a <a href="http://www.nature.com/nbt/journal/v26/n8/full/nbt.1411.html">Minimum Information (MI)</a>
+		standard for plant phenotyping.  It defines a list of attributes that might be necessary to fully describe a
+		phenotyping experiment, following <a href="http://fged.org/projects/miame/">the model originally established for
+		microarray data</a>. Not all of the elements listed in an MI must be reported in each case. An MI document should
+		rather be considered as a checklist, and consulted by a person describing or depositing the data to ensure the
+		inclusion of all important data characteristics, i.e. what is meaningful for the interpretation and potential
+		replication of the research.
+	</p>
  
-<p>MIAPPE is a logical standard - but there are specific implementations of tools designed to support its use and application, for example, in the <a hef="http://isa-tools.org">ISA-tools</a> framework. We are working with the developers of the <a href="http://www.brapi.org">Plant Breeding API</a> (BRAPI) to ensure the compliance of BRAPI with the MIAPPE standard, and to coordinate future developments.</p>
- <p>MIAPPE was originally been developed in the context of the transPLANT, European Plant Phenotyping Network and ELIXIR-EXCELERATE projects, but we are keen to work with anyone interested in contributing to, reviewing or using the standard, or developing new tools.<p>
+	<p>
+		MIAPPE is a logical standard - but there are specific implementations of tools designed to support its use and
+		application, for example, in the <a hef="http://isa-tools.org">ISA-tools</a> framework. We are working with the
+		developers of the <a href="http://www.brapi.org">Plant Breeding API</a> (BRAPI) to ensure the compliance of BRAPI with
+		the MIAPPE standard, and to coordinate future developments.
+	</p>
+ 	<p>
+		MIAPPE was originally been developed in the context of the transPLANT, European Plant Phenotyping Network and
+		ELIXIR-EXCELERATE projects, but we are keen to work with anyone interested in contributing to, reviewing or using the
+		standard, or developing new tools.
+	<p>
 
 <h3>Releases</h3>
 <h4>MIAPPE v1.1, January 2019</h4>
@@ -56,16 +92,29 @@ order: 1
 		relied on two requests for comments.  Major developments over v1.0 include:</p> 
 	<ul>
 	<li>The extension of MIAPPE’s scope to accommodate woody plants as an additional use-case.</li>
-	<li>The specification of a data model for MIAPPE, to facilitate its implementation in various formats and enable its automatic validation.</li>
-	<li>Compatibility of the MIAPPE logical standard with common frameworks for representing these data types, namely <a href="https://isa-tools.org:">ISA-Tools</a> and the <a href="https://brapi.docs.apiary.io/#">Breeding API (BrAPI)</a>.</li>
+	<li>
+		The specification of a data model for MIAPPE, to facilitate its implementation in various formats and enable its
+		automatic validation.
+	</li>
+	<li>
+		Compatibility of the MIAPPE logical standard with common frameworks for representing these data types, namely
+		<a href="https://isa-tools.org:">ISA-Tools</a> and the
+		<a href="https://brapi.docs.apiary.io/#">Breeding API (BrAPI)</a>.
+	</li>
 	<li>The enrichment of MIAPPE, with the provision of clear definitions and examples for all fields.</li>
 	</ul>
-	<p>A <a href="https://nph.onlinelibrary.wiley.com/doi/abs/10.1111/nph.16544">new paper</a> describing the application of MIAPPE v1.1 to a variety of use cases has just been published in the New Phytologist.
-		Meanwhile, improvements can be suggested via miappe-feedback@ebi.ac.uk.  Work is now commencing on the next version of MIAPPE, v2.0.  Development is at an early stage and all contributions are welcome.
+	<p>
+		A <a href="https://nph.onlinelibrary.wiley.com/doi/abs/10.1111/nph.16544">new paper</a> describing the application of
+		MIAPPE v1.1 to a variety of use cases has just been published in the New Phytologist.
+		Meanwhile, improvements can be suggested via miappe-feedback@ebi.ac.uk.  Work is now commencing on the next version of
+		MIAPPE, v2.0.  Development is at an early stage and all contributions are welcome.
 	</p> 	
 <h4>MIAPPE v1, July 2016</h4>
-	<p>The <a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-v1.0">initial version of MIAPPE</a> has been designed as a checklist, 
-		following the approach of international deposition databases. It is now extended by MIAPPE v1.1.</p>
+	<p>
+		The <a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-v1.0">initial version of MIAPPE</a> has
+		been designed as a checklist, following the approach of international deposition databases. It is now extended by
+		MIAPPE v1.1.
+	</p>
 
   {% comment %}
   DISABLED

--- a/overview.html
+++ b/overview.html
@@ -4,41 +4,51 @@ title: Overview
 ---
 <h3>Overview</h3>
 
-The Minimum Information About Plant Phenotyping Experiments (MIAPPE) is a data standard designed to harmonize the description of experimental and computed data 
-to enable its sharing, publication and reuse. 
-It is designed to handle datasets of crops and woody plant grown in greenhouses, single fields or experimental networks overs one to several years.
+The Minimum Information About Plant Phenotyping Experiments (MIAPPE) is a data standard designed to harmonize the description
+of experimental and computed data to enable its sharing, publication and reuse. 
+It is designed to handle datasets of crops and woody plant grown in greenhouses, single fields or experimental networks overs
+one to several years.
 
 
-The main elements of a MIAPPE datasets are shown on the figure below and consist of the Dataset itself (or Investigation following ISA), the Study, the Biological Material and the Observation Variables.
+The main elements of a MIAPPE datasets are shown on the figure below and consist of the Dataset itself (or Investigation
+following ISA), the Study, the Biological Material and the Observation Variables.
 </br>
 <img src="//miappe.github.io//miappe-website/static/MIAPPE-OVERVIEW-nutshell.png" />
 </br>
-See the latest <a href="https://github.com/MIAPPE/MIAPPE">MIAPPE specifications</a> (<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.pdf">PDF format</a>
-        <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">data exchange templates </a>) for a full description of the standard.
+See the latest <a href="https://github.com/MIAPPE/MIAPPE">MIAPPE specifications</a>
+(<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.pdf">PDF format</a>
+<a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">data exchange templates </a>) for a full description
+of the standard.
 
 <h4>Dataset (Investigation)</h4>
 It contains the basic information shared by any type of datasets: title, authors list, description, a DOI for citability, etc....
 
 <h4>Studies</h4>
-A MIAPPE dataset contains one to many Studies, each studies being one experiment in one location over one to several years. This multiannual capabilities allows to handle perenial
-plants such as trees or grape. A Study can also be virtual to hold the result of a computation voer one to several experimental studies.
-It contains also the geographical coordinates of the Study.
+A MIAPPE dataset contains one to many Studies, each studies being one experiment in one location over one to several years.
+This multiannual capabilities allows to handle perenial plants such as trees or grape. A Study can also be virtual to hold the
+result of a computation voer one to several experimental studies. It contains also the geographical coordinates of the Study.
 
 <h4>Biological Material</h4>
 This is one of the two most essential description to enable FAIR data sharing. 
-It is the biological material being studied (e.g. plants grown from a certain bag or seed, or plants grown in a particular field) including identification and traceability. The original source of that material (e.g., the seeds or the original plant cloned) is called the material source, which, when held by a material repository, should have its stock identified.
+It is the biological material being studied (e.g. plants grown from a certain bag or seed, or plants grown in a particular
+field) including identification and traceability. The original source of that material (e.g., the seeds or the original plant
+cloned) is called the material source, which, when held by a material repository, should have its stock identified.
 
 <h4>Observed Variable</h4>
-An observed variable describes how a measurement has been made. It typically takes the form of a measured characteristic of the observation unit (plant or environmental trait), associated to the method and unit of measurement. Multiple variables with the same combination of trait, method and scale can be used in association with different plant parts (leaf 1, leaf 2), 
+An observed variable describes how a measurement has been made. It typically takes the form of a measured characteristic of
+the observation unit (plant or environmental trait), associated to the method and unit of measurement. Multiple variables with
+the same combination of trait, method and scale can be used in association with different plant parts (leaf 1, leaf 2), 
 when this distinction is necessary for observations referring to different parts of the same observation unit.
 
 <h3>Implementations</h3>
 MIAPPE is a pure specification that has been implemented in several systems and tools:
 <ul>
-        <li>MIAPPE is a key element in the <a href="https://rdmkit.elixir-europe.org/plant_sciences">RDM Kit plant domain</a> as well as 
-                the <a href="https://rdmkit.elixir-europe.org/plant_phenomics_assembly"plant phenomic tool assembly</a></li>
-        <li>Databases such as <a href="http://www.phis.inra.fr/">PHIS</a>, <a href="https://urgi.versailles.inra.fr/gnpis">GnpIS</a>, ...</li>
-        <li>File archives and in particular ISA-MIAPPE</li>
-        <li>the <a href="https://brapi.org">Breeding API</a> web services</li>
+  <li>
+    MIAPPE is a key element in the <a href="https://rdmkit.elixir-europe.org/plant_sciences">RDM Kit plant domain</a> as well
+    as the <a href="https://rdmkit.elixir-europe.org/plant_phenomics_assembly">plant phenomic tool assembly</a>
+  </li>
+  <li>Databases such as <a href="http://www.phis.inra.fr/">PHIS</a>, <a href="https://urgi.versailles.inra.fr/gnpis">GnpIS</a>, ...</li>
+  <li>File archives and in particular ISA-MIAPPE</li>
+  <li>the <a href="https://brapi.org">Breeding API</a> web services</li>
 </ul>
  

--- a/people.html
+++ b/people.html
@@ -18,10 +18,6 @@ Members of this committee can also be active developers of the standard. The cur
 		Gatersleben, Germany)
 	</li>
 	<li>
-		<a href="https://orcid.org/0000-0002-6020-5919">Elizabeth Arnaud</a>
-		(<a href="http://www.bioversityinternational.org">Bioversity International</a>, Montpellier, France)
-	</li>	
-	<li>
 		<a href="https://www.danforthcenter.org/our-work/principal-investigators/noah-fahlgren/">Noah Fahlgren</a>
 		(<a href="https://www.danforthcenter.org/">Donald Danforth Plant Science Center</a>, United States of America)
 	</li>
@@ -44,6 +40,10 @@ Members of this committee can also be active developers of the standard. The cur
 
 <p>Previous members</p>
 <ul>
+	<li>
+		<a href="https://orcid.org/0000-0002-6020-5919">Elizabeth Arnaud</a>
+		(<a href="http://www.bioversityinternational.org">Bioversity International</a>, Montpellier, France)
+	</li>
 	<li>
 		<a href="https://www.kew.org/science/who-we-are-and-what-we-do/people/paul-kersey">Paul Kersey</a>
 		(<a href="http://www.ebi.ac.uk">Royal Botanic Gardens, Kew</a>, United Kingdom)

--- a/people.html
+++ b/people.html
@@ -8,23 +8,58 @@ order: 5
 
 <h2>Steering commitee</h2>
 	
-Development of MIAPPE is currently overseen by a steering committee whose members represent a variety of interested countries, institutes and projects.  
+Development of MIAPPE is currently overseen by a steering committee whose members represent a variety of interested countries,
+institutes and projects.  
 Members of this committee can also be active developers of the standard. The current committee comprises:
     <ul>
-	<li><a href="https://orcid.org/0000-0002-2455-5938">Daniel Arend</a> (<a href="http://www.ipk-gatersleben.de/index.php?id=1&L=1">Leibniz-Institut Für Pflanzengenetik und Kulturpflanzenforschung</a>, Gatersleben, Germany)
-	<li><a href="http://www.bioversityinternational.org/about-us/who-we-are/staff-bios/single-details-bios/arnaud-elizabeth/">Elizabeth Arnaud</a> (<a href="http://www.bioversityinternational.org">Bioversity International</a>, Montpellier, France)	
-	<li><a href="https://www.danforthcenter.org/our-work/principal-investigators/noah-fahlgren/">Noah Fahlgren</a> (<a href="https://www.danforthcenter.org/">Danforth Plant Science Center</a>, United States of America)
-        <li><a href="http://www.igr.poznan.pl/about-us-en/structure-en/department-of-biometry-and-bioinformatics/biometry-and-bioinformatics-team">Paweł Krajewski</a> (<a href="http://www.igr.poznan.pl/en/home">Institute of Plant Genetics, Polish Academy of Sciences</a>, Poznań, Poland)
-	<li><a href="https://orcid.org/0000-0003-3631-4493">Mohsen Yoosefzadeh Najafabadi</a> (<a href="http://www.uoguelph.ca/">University of Guelph, Ontario</a>, Canada)	
-        <li><a href="https://orcid.org/0000-0002-9040-8733">Cyril Pommier</a> (<a href="https://urgi.versailles.inrae.fr">INRAE</a>, Versailles, France)
+	<li>
+		<a href="https://orcid.org/0000-0002-2455-5938">Daniel Arend</a>
+		(<a href="http://www.ipk-gatersleben.de/index.php?id=1&L=1">Leibniz-Institut Für Pflanzengenetik und Kulturpflanzenforschung</a>,
+		Gatersleben, Germany)
+	</li>
+	<li>
+		<a href="http://www.bioversityinternational.org/about-us/who-we-are/staff-bios/single-details-bios/arnaud-elizabeth/">Elizabeth Arnaud</a>
+		(<a href="http://www.bioversityinternational.org">Bioversity International</a>, Montpellier, France)
+	</li>	
+	<li>
+		<a href="https://www.danforthcenter.org/our-work/principal-investigators/noah-fahlgren/">Noah Fahlgren</a>
+		(<a href="https://www.danforthcenter.org/">Danforth Plant Science Center</a>, United States of America)
+	</li>
+    <li>
+		<a href="http://www.igr.poznan.pl/about-us-en/structure-en/department-of-biometry-and-bioinformatics/biometry-and-bioinformatics-team">Paweł Krajewski</a>
+		(<a href="http://www.igr.poznan.pl/en/home">Institute of Plant Genetics, Polish Academy of Sciences</a>, Poznań, Poland)
+	</li>
+	<li>
+		<a href="https://orcid.org/0000-0003-3631-4493">Mohsen Yoosefzadeh Najafabadi</a>
+		(<a href="http://www.uoguelph.ca/">University of Guelph, Ontario</a>, Canada)
+	</li>
+    <li>
+		<a href="https://orcid.org/0000-0002-9040-8733">Cyril Pommier</a>
+		(<a href="https://urgi.versailles.inrae.fr">INRAE</a>, Versailles, France)
+	</li>
     </ul>
-	Among the current projects of the steering committee is the development of a full governance mechanism including the election of future versions of the committee.  Minutes of the committee's meetings are published on GitHub; read them <a href="https://github.com/MIAPPE/SteeringCommittee/tree/master/meeting_minutes">here</a>.
+	Among the current projects of the steering committee is the development of a full governance mechanism including the
+	election of future versions of the committee.  Minutes of the committee's meetings are published on GitHub; read them
+	<a href="https://github.com/MIAPPE/SteeringCommittee/tree/master/meeting_minutes">here</a>.<br><br>
+
 <p>Previous members</p>
 <ul>
-	<li><a href="https://www.kew.org/science/who-we-are-and-what-we-do/people/paul-kersey">Paul Kersey</a> (<a href="http://www.ebi.ac.uk">Royal Botanic Gardens, Kew</a>, United Kingdom)	
-        <li><a href="https://orcid.org/0000-0002-4316-078X">Matthias Lange</a> (<a href="http://www.ipk-gatersleben.de/index.php?id=1&L=1">Leibniz-Institut Für Pflanzengenetik und Kulturpflanzenforschung</a>, Gatersleben, Germany)
-	<li><a href="https://www.gdcb.iastate.edu/people/carolyn-lawrence-dill">Carolyn Lawrence-Dill</a> (<a href="https://www.iastate.edu">Iowa State University</a>, United States of America)
-	<li><a href="http://usadellab.org/cms/">Bjoern Usadel</a> (<a href="http://www.fz-juelich.de/portal/DE/Home/home_node.html">Forschungszentrum Jülich</a>, Germany)
+	<li>
+		<a href="https://www.kew.org/science/who-we-are-and-what-we-do/people/paul-kersey">Paul Kersey</a>
+		(<a href="http://www.ebi.ac.uk">Royal Botanic Gardens, Kew</a>, United Kingdom)
+	</li>
+    <li>
+		<a href="https://orcid.org/0000-0002-4316-078X">Matthias Lange</a>
+		(<a href="http://www.ipk-gatersleben.de/index.php?id=1&L=1">Leibniz-Institut Für Pflanzengenetik und Kulturpflanzenforschung</a>, Gatersleben, Germany)
+	</li>
+	<li>
+		<a href="https://www.gdcb.iastate.edu/people/carolyn-lawrence-dill">Carolyn Lawrence-Dill</a>
+		(<a href="https://www.iastate.edu">Iowa State University</a>, United States of America)
+	</li>
+	<li>
+		<a href="http://usadellab.org/cms/">Bjoern Usadel</a>
+		(<a href="http://www.fz-juelich.de/portal/DE/Home/home_node.html">Forschungszentrum Jülich</a>, Germany)
+	</li>
 	
 </ul>
   <h2>Developers</h2>	
@@ -54,7 +89,9 @@ Members of this committee can also be active developers of the standard. The cur
   If you have also been involved, and would like to have your name added here, please send a mail to <a href="mailto:miappe-steering@ebi.ac.uk">miappe-steering@ebi.ac.uk</a>.
 	   
 <h2>Join the MIAPPE community</h2>
-To be informed of new developments in MIAPPE, please consider subscribing to the <a href="http://listserver.ebi.ac.uk/mailman/listinfo/miappe">MIAPPE mailing list</a>.  Traffic is low, but it subscribers are informed of future meetings, proposed revisions to the standard, and new tools.
+To be informed of new developments in MIAPPE, please consider subscribing to the
+<a href="http://listserver.ebi.ac.uk/mailman/listinfo/miappe">MIAPPE mailing list</a>. 
+Traffic is low, but it subscribers are informed of future meetings, proposed revisions to the standard, and new tools.
 
 
 

--- a/people.html
+++ b/people.html
@@ -21,9 +21,17 @@ Members of this committee can also be active developers of the standard. The cur
 		<a href="https://www.danforthcenter.org/our-work/principal-investigators/noah-fahlgren/">Noah Fahlgren</a>
 		(<a href="https://www.danforthcenter.org/">Donald Danforth Plant Science Center</a>, United States of America)
 	</li>
+	<li>
+		<a href="https://orcid.org/0000-0002-5520-5287">Marc Heuermann</a>
+		(<a href="https://www.ipk-gatersleben.de/">Leibniz Institute of Plant Genetics and Crop Plant Research</a>, Gatersleben, Germany)
+	</li>
     <li>
 		<a href="https://www.igr.poznan.pl/en/about-institute-board-of-directors">Paweł Krajewski</a>
 		(<a href="https://www.igr.poznan.pl/en">Institute of Plant Genetics, Polish Academy of Sciences</a>, Poznań, Poland)
+	</li>
+	<li>
+		<a href="https://alliancebioversityciat.org/who-we-are/marie-angelique-laporte">Marie Angélique Laporte</a>
+		(<a href="https://alliancebioversityciat.org/">Alliance of Bioversity International and CIAT</a>, Montpellier, France)
 	</li>
 	<li>
 		<a href="https://orcid.org/0000-0003-3631-4493">Mohsen Yoosefzadeh Najafabadi</a>

--- a/people.html
+++ b/people.html
@@ -14,20 +14,20 @@ Members of this committee can also be active developers of the standard. The cur
     <ul>
 	<li>
 		<a href="https://orcid.org/0000-0002-2455-5938">Daniel Arend</a>
-		(<a href="http://www.ipk-gatersleben.de/index.php?id=1&L=1">Leibniz-Institut Für Pflanzengenetik und Kulturpflanzenforschung</a>,
+		(<a href="https://www.ipk-gatersleben.de/index.php?id=1&L=1">Leibniz-Institut Für Pflanzengenetik und Kulturpflanzenforschung</a>,
 		Gatersleben, Germany)
 	</li>
 	<li>
-		<a href="http://www.bioversityinternational.org/about-us/who-we-are/staff-bios/single-details-bios/arnaud-elizabeth/">Elizabeth Arnaud</a>
+		<a href="https://orcid.org/0000-0002-6020-5919">Elizabeth Arnaud</a>
 		(<a href="http://www.bioversityinternational.org">Bioversity International</a>, Montpellier, France)
 	</li>	
 	<li>
 		<a href="https://www.danforthcenter.org/our-work/principal-investigators/noah-fahlgren/">Noah Fahlgren</a>
-		(<a href="https://www.danforthcenter.org/">Danforth Plant Science Center</a>, United States of America)
+		(<a href="https://www.danforthcenter.org/">Donald Danforth Plant Science Center</a>, United States of America)
 	</li>
     <li>
-		<a href="http://www.igr.poznan.pl/about-us-en/structure-en/department-of-biometry-and-bioinformatics/biometry-and-bioinformatics-team">Paweł Krajewski</a>
-		(<a href="http://www.igr.poznan.pl/en/home">Institute of Plant Genetics, Polish Academy of Sciences</a>, Poznań, Poland)
+		<a href="https://www.igr.poznan.pl/en/about-institute-board-of-directors">Paweł Krajewski</a>
+		(<a href="https://www.igr.poznan.pl/en">Institute of Plant Genetics, Polish Academy of Sciences</a>, Poznań, Poland)
 	</li>
 	<li>
 		<a href="https://orcid.org/0000-0003-3631-4493">Mohsen Yoosefzadeh Najafabadi</a>
@@ -86,11 +86,11 @@ Members of this committee can also be active developers of the standard. The cur
 	    <li><a href="http://www.ipk-gatersleben.de/bioinformatik/">Uwe Scholz</a> (<a href="http://www.ipk-gatersleben.de/index.php?id=1&L=1">Leibniz-Institut Für Pflanzengenetik und Kulturpflanzenforschung</a>, Gatersleben, Germany)
 	    <li><a href="https://www.gmi.oeaw.ac.at/research-groups/magnus-nordborg/group-members/">Ümit Seren</a> (<a href="https://www.gmi.oeaw.ac.at">Gregor Mendel Institute</a>, Vienna, Austria)
 	  </ul>
-  If you have also been involved, and would like to have your name added here, please send a mail to <a href="mailto:miappe-steering@ebi.ac.uk">miappe-steering@ebi.ac.uk</a>.
+  If you have also been involved, and would like to have your name added here, please send a mail to <a href="mailto:miappe-sc@elixir-europe.org">miappe-sc@elixir-europe.org</a>.
 	   
 <h2>Join the MIAPPE community</h2>
 To be informed of new developments in MIAPPE, please consider subscribing to the
-<a href="http://listserver.ebi.ac.uk/mailman/listinfo/miappe">MIAPPE mailing list</a>. 
+<a href="https://mail.elixir-europe.org/mailman/listinfo/miappe_elixir-europe.org">MIAPPE mailing list</a>. 
 Traffic is low, but it subscribers are informed of future meetings, proposed revisions to the standard, and new tools.
 
 

--- a/projects.html
+++ b/projects.html
@@ -9,7 +9,7 @@ order: 6
   
 	<p>
 		MIAPPE was initiated in the context of the <a href="http://transplantdb.eu">transPLANT</a> project, which was funded
-		by the <a href="http://ec.europa.eu/index_en.htm">European Commission</a> within its
+		by the <a href="https://commission.europa.eu/index_en">European Commission</a> within its
 		<a href="http://cordis.europa.eu/fp7/home_en.html">7th Framework Programme</a> under the thematic area
 		&quot;Infrastructures&quot;, in collaboration with the European Plant Phenotyping Network
 		(<a href="http://www.plant-phenotyping-network.eu/">EPPN</a>). It is being maintained, extended and applied in the

--- a/projects.html
+++ b/projects.html
@@ -7,8 +7,14 @@ order: 6
 <div class="blurb">
 	<h2>Projects</h2>
   
-	<p>MIAPPE was initiated in the context of the <a href="http://transplantdb.eu">transPLANT</a> project, which was funded by the <a href="http://ec.europa.eu/index_en.htm">European Commission</a> within its <a href="http://cordis.europa.eu/fp7/home_en.html">7th Framework Programme</a> under the thematic area &quot;Infrastructures&quot;, in collaboration with the European Plant Phenotyping Network (<a href="http://www.plant-phenotyping-network.eu/">EPPN</a>). 
-	It is being maintained, extended and applied in the context of several infrastructures and projects: </p>
+	<p>
+		MIAPPE was initiated in the context of the <a href="http://transplantdb.eu">transPLANT</a> project, which was funded
+		by the <a href="http://ec.europa.eu/index_en.htm">European Commission</a> within its
+		<a href="http://cordis.europa.eu/fp7/home_en.html">7th Framework Programme</a> under the thematic area
+		&quot;Infrastructures&quot;, in collaboration with the European Plant Phenotyping Network
+		(<a href="http://www.plant-phenotyping-network.eu/">EPPN</a>). It is being maintained, extended and applied in the
+		context of several infrastructures and projects:
+	</p>
 	<ul>
 		<li> The H2020 <a href="https://www.elixir-europe.org/excelerate">ELIXIR-EXCELERATE</a> project.
 		<li> The <a href="https://www.elixir-europe.org">ELIXIR</a>European infrastructure for Life Science informatics.

--- a/support.html
+++ b/support.html
@@ -33,8 +33,8 @@ order: 3
 
 <h5>Publications</h5>
   <p>
-    See the <a href="https://www.miappe.org/publications/">Publication page</a> for detailled description of the principles,
-    the history and the impolementation of MIAPPE.
+    See the <a href="https://www.miappe.org/publications/">Publication page</a> for a detailled description of the principles,
+    the history and the implementation of MIAPPE.
   </p>
 
 <h5>Implementations and Tools</h5>  

--- a/support.html
+++ b/support.html
@@ -7,7 +7,10 @@ order: 3
 
 <h3>Support</h3>
 
-<p>General questions regarding MIAPPE usage can be asked on the <a href="https://mail.elixir-europe.org/mailman/listinfo/miappe_elixir-europe.org">MIAPPE mailing list</a>.</p>
+<p>
+  General questions regarding MIAPPE usage can be asked on the
+  <a href="https://mail.elixir-europe.org/mailman/listinfo/miappe_elixir-europe.org">MIAPPE mailing list</a>.
+</p>
 
 <h3>Documentations and Resources</h3>
   
@@ -15,36 +18,66 @@ order: 3
   
   <ul>
     <li>The current version of
-        <a href="https://github.com/MIAPPE/MIAPPE">MIAPPE</a> (<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.pdf">PDF format</a>
-        <a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.xlsx">.xlsx format</a>) with training material and <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">data templates </a>.</li>
-    <li>The previous versions of MIAPPE can be found in the Arhcives <a href="https://github.com/MIAPPE/MIAPPE/blob/master/README.md"></a> </li>
+        <a href="https://github.com/MIAPPE/MIAPPE">MIAPPE</a>
+        (<a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.pdf">PDF format</a>
+        <a href="https://github.com/MIAPPE/MIAPPE/blob/master/MIAPPE_Checklist_Data_Model.xlsx">.xlsx format</a>)
+        with training material and <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">data templates </a>.
+    </li>
+    <li>
+      The previous versions of MIAPPE can be found in the Arhcives
+      <a href="https://github.com/MIAPPE/MIAPPE/blob/master/README.md"></a>
+    </li>
 </ul>
 
 
 
 <h5>Publications</h5>
-  See the <a href="https://www.miappe.org/publications/">Publication page</a> for detailled description of the principles, the history and the impolementation of MIAPPE.   
-  <br>
+  <p>
+    See the <a href="https://www.miappe.org/publications/">Publication page</a> for detailled description of the principles,
+    the history and the impolementation of MIAPPE.
+  </p>
 
 <h5>Implementations and Tools</h5>  
- <ul> 
-	 <li>The <a href="http://brapi.org">Breeding API</a> is a web service specificaiton that implements several standards including MIAPPE</li>
-	 <li><a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">Recommended templates</a> can be used for data exchange, database submissions, and training.</li>
-	 <li>The current implementation of the MIAPPE standard in <a href="http://cropnet.pl/phenotypes/?page_id=37">ISA-Tab format</a>.</li>
+ <ul>
+  <li>
+    The <a href="http://brapi.org">Breeding API</a> is a web service specificaiton that implements several standards
+    including MIAPPE
+  </li>
+	<li>
+    <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">Recommended templates</a> can be used for data exchange,
+    database submissions, and training.
+  </li>
+	<li>
+    The current implementation of the MIAPPE standard in
+    <a href="http://cropnet.pl/phenotypes/?page_id=37">ISA-Tab format</a>.
+  </li>
  </ul>   
   
   <h5>Miscellaneous links</h5>
   <ul> 
-    <li> <a href="https://fairsharing.org/">FAIRsharing.org</a> is a standard and databases registries and include a <a href="https://doi.org/10.25504/FAIRsharing.nd9ce9">MIAPPE record</a>.</li>
-    <li>More information about the ISA-tab for phenotyping: <a href="http://cropnet.pl/phenotypes/?page_id=37">concept</a> and <a href="http://cropnet.pl/phenotypes/?p=167">use</a>; and more generally, about the <a href="http://www.isa-tools.org">Investigation-Study-Assay file format</a>.</li>
-    <li>A mapping of MIAPPE terms to the checklist for the submission of plant nucleic acid sequence to the European Nucleotide Archive (coming soon).</li>
+    <li>
+      <a href="https://fairsharing.org/">FAIRsharing.org</a> is a standard and databases registries and include a
+      <a href="https://doi.org/10.25504/FAIRsharing.nd9ce9">MIAPPE record</a>.
+    </li>
+    <li>
+      More information about the ISA-tab for phenotyping: <a href="http://cropnet.pl/phenotypes/?page_id=37">concept</a> and
+      <a href="http://cropnet.pl/phenotypes/?p=167">use</a>; and more generally, about the
+      <a href="http://www.isa-tools.org">Investigation-Study-Assay file format</a>.
+    </li>
+    <li>
+      A mapping of MIAPPE terms to the checklist for the submission of plant nucleic acid sequence to the European Nucleotide
+      Archive (coming soon).
+    </li>
    </ul>
     
     <h5>Project resources</h5>
     <ul>
         <li>The <a href="https://github.com/MIAPPE">MIAPPE GitHub repository</a>.</li>
         <li>The associated <a href="https://github.com/MIAPPE/MIAPPE/issues">GitHub issue tracker</a>.</li>
-    <li>An <a href="http://cropnet.pl/phenotypes/?page_id=71">archive</a> of previous versions of the MIAPPE specification and ISA-Tab configurations.</li>
+        <li>
+          An <a href="http://cropnet.pl/phenotypes/?page_id=71">archive</a> of previous versions of the MIAPPE specification
+          and ISA-Tab configurations.
+        </li>
   </ul>
   
 

--- a/support.html
+++ b/support.html
@@ -24,8 +24,8 @@ order: 3
         with training material and <a href="https://github.com/MIAPPE/MIAPPE/tree/master/Templates">data templates </a>.
     </li>
     <li>
-      The previous versions of MIAPPE can be found in the Arhcives
-      <a href="https://github.com/MIAPPE/MIAPPE/blob/master/README.md"></a>
+      The previous versions of MIAPPE can be found in the
+      <a href="https://github.com/MIAPPE/MIAPPE/releases">previous releases</a>.
     </li>
 </ul>
 

--- a/support.html
+++ b/support.html
@@ -56,7 +56,7 @@ order: 3
   <h5>Miscellaneous links</h5>
   <ul> 
     <li>
-      <a href="https://fairsharing.org/">FAIRsharing.org</a> is a standard and databases registries and include a
+      <a href="https://fairsharing.org/">FAIRsharing.org</a> is a registry of standards and databases and includes a
       <a href="https://doi.org/10.25504/FAIRsharing.nd9ce9">MIAPPE record</a>.
     </li>
     <li>


### PR DESCRIPTION
This PR adds MIAPPE version 1.2 to the releases and includes general website maintenance, including:
* Some spelling and grammar improvements
* Code reformatting for easier editing
* Updated URLs for some links
* Updated Steering Committee list