### PR TITLE
Fix data links

### DIFF
--- a/data.html
+++ b/data.html
@@ -18,7 +18,7 @@ order: 9
 			<td><a href="https://github.com/MIAPPE/MIAPPE/tree/v1.1.1/MIAPPE_Checklist-Data-Model-v1.1/MIAPPE_submission_template">MIAPPE EXCEL Templates</td>
 		</tr>
 			<tr>
-			<td><a href="http://dx.doi.org/10.1093/gigascience/giy001">Chen <i> et al.</i> 2018</a></td>
+			<td><a href="https://dx.doi.org/10.1093/gigascience/giy001">Chen <i> et al.</i> 2018</a></td>
 			<td>
 				<li><a href="https://dx.doi.org/10.5447/IPK/2017/24">https://dx.doi.org/10.5447/IPK/2017/24</a>
 				<li><a href="https://dx.doi.org/10.5447/IPK/2017/25">https://dx.doi.org/10.5447/IPK/2017/25</a>
@@ -27,8 +27,8 @@ order: 9
 			<td><a href="http://cropnet.pl/phenotypes/?page_id=37">ISA-Tab for Phenotyping</td>
 		</tr>
 		<tr>
-			<td><a href="http://dx.doi.org/10.1038/sdata.2016.55">Arend <i> et al.</i> 2016</a></td>
-			<td><a href="http://data.datacite.org/10.5447/IPK/2016/7 ">http://data.datacite.org/10.5447/IPK/2016/7</a></td>
+			<td><a href="https://dx.doi.org/10.1038/sdata.2016.55">Arend <i> et al.</i> 2016</a></td>
+			<td><a href="https://data.datacite.org/10.5447/IPK/2016/7 ">http://data.datacite.org/10.5447/IPK/2016/7</a></td>
 			<td><a href="http://cropnet.pl/phenotypes/?page_id=37">ISA-Tab for Phenotyping</td>
 		</tr>
 	</table>

--- a/data.html
+++ b/data.html
@@ -15,7 +15,7 @@ order: 9
 		<tr>
 			<td><a href="https://doi.org/10.15454/IASSTN">Millet <i> et al.</i> 2019</a></td>
 			<td><a href="https://doi.org/10.15454/IASSTN">https://doi.org/10.15454/IASSTN</td>
-			<td><a href="https://github.com/MIAPPE/MIAPPE/tree/master/MIAPPE_Checklist-Data-Model-v1.1/MIAPPE_templates">MIAPPE EXCEL Templates</td>
+			<td><a href="https://github.com/MIAPPE/MIAPPE/tree/v1.1.1/MIAPPE_Checklist-Data-Model-v1.1/MIAPPE_submission_template">MIAPPE EXCEL Templates</td>
 		</tr>
 			<tr>
 			<td><a href="http://dx.doi.org/10.1093/gigascience/giy001">Chen <i> et al.</i> 2018</a></td>

--- a/data.html
+++ b/data.html
@@ -28,7 +28,7 @@ order: 9
 		</tr>
 		<tr>
 			<td><a href="https://dx.doi.org/10.1038/sdata.2016.55">Arend <i> et al.</i> 2016</a></td>
-			<td><a href="https://data.datacite.org/10.5447/IPK/2016/7 ">http://data.datacite.org/10.5447/IPK/2016/7</a></td>
+			<td><a href="https://data.datacite.org/10.5447/IPK/2016/7 ">https://data.datacite.org/10.5447/IPK/2016/7</a></td>
 			<td><a href="http://cropnet.pl/phenotypes/?page_id=37">ISA-Tab for Phenotyping</td>
 		</tr>
 	</table>


### PR DESCRIPTION
This PR fixes the link to the MIAPPE submission template directory, which was available for v1.1 but was later removed.

The site http://cropnet.pl is down, so the links to http://cropnet.pl/phenotypes/?page_id=37 are not working. @cpommier can this link substitute for it? https://github.com/MIAPPE/ISA-Tab-for-plant-phenotyping/tree/v1.1

Addresses issue https://github.com/MIAPPE/MIAPPE/issues/131
